### PR TITLE
Remove Google tracking and round site elements

### DIFF
--- a/all.html
+++ b/all.html
@@ -2,20 +2,12 @@
 <head>
   <meta charset="UTF-8">
   <title>مملكة العطور - الواجهة الجديدة</title>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-N8G1EZJT5B');
-</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
     body {
-      font-family: 'Cairo', sans-serif;
+      font-family: sans-serif;
       background-color: #f8fafc;
       overflow-x: hidden;
     }
@@ -23,7 +15,7 @@
     .product {
       background: white;
       padding: 1rem;
-      border-radius: 12px;
+      border-radius: 20px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       text-align: center;
       display: flex;
@@ -36,7 +28,7 @@
       max-width: 100%;
       height: 250px;
       object-fit: contain;
-      border-radius: 8px;
+      border-radius: 12px;
       margin-bottom: 1rem;
     }
     .product h3 {
@@ -66,7 +58,7 @@
       color: #1f2937;
       border: none;
       padding: 0.6rem 1rem;
-      border-radius: 6px;
+      border-radius: 12px;
       cursor: pointer;
       font-size: 0.95rem;
       transition: 0.3s;
@@ -100,11 +92,11 @@
     <div class="container mx-auto px-4">
       <h2 id="category-heading" class="text-2xl font-bold mb-6 text-center"></h2>
       <div class="flex flex-col md:flex-row gap-4 justify-between mb-6">
-        <form id="searchForm" class="flex bg-white rounded-lg overflow-hidden flex-1">
+        <form id="searchForm" class="flex bg-white rounded-full overflow-hidden flex-1">
           <input type="text" id="searchInput" placeholder="ابحث عن عطر..." class="px-4 py-2 flex-1 outline-none">
           <button type="submit" class="px-4 py-2 text-white"> <i class="fas fa-search"></i> </button>
         </form>
-        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded border border-gray-300">
+        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded-full border border-gray-300">
           <option value="all">جميع الأسعار</option>
           <option value="0-20000">أقل من 20000</option>
           <option value="20000-50000">20000 - 50000</option>

--- a/index.html
+++ b/index.html
@@ -7,13 +7,12 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
-    body { font-family: 'Cairo', sans-serif; background-color: #f8fafc; overflow-x: hidden; }
+    body { font-family: sans-serif; background-color: #f8fafc; overflow-x: hidden; }
     .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;
-      border-radius: 12px;
+      border-radius: 20px;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);
       text-align: center;
       display: flex;
@@ -25,7 +24,7 @@
       max-width: 100%;
       height: 150px;
       object-fit: contain;
-      border-radius: 8px;
+      border-radius: 12px;
       margin-bottom: 0.5rem;
     }
     .product h3 { font-size: 1rem; margin-bottom: 0.25rem; color: #1e293b; overflow-wrap: anywhere; }
@@ -38,7 +37,7 @@
       color: #1f2937;
       border: none;
       padding: 0.4rem 0.6rem;
-      border-radius: 6px;
+      border-radius: 12px;
       cursor: pointer;
       font-size: 0.85rem;
       transition: 0.3s;
@@ -59,7 +58,7 @@
   </header>
 
   <div id="searchControls" class="container mx-auto px-4 py-4">
-    <form id="searchForm" class="flex bg-white rounded-lg overflow-hidden">
+    <form id="searchForm" class="flex bg-white rounded-full overflow-hidden">
       <input id="searchField" type="text" placeholder="ابحث..." class="px-3 py-2 text-gray-700 outline-none flex-1">
       <button type="submit" class="px-3 py-2 bg-yellow-500 text-white"><i class="fas fa-search"></i></button>
     </form>
@@ -78,19 +77,19 @@
     <div class="container mx-auto px-4">
       <h3 class="text-3xl font-bold mb-8 text-center text-yellow-700">الفئات الرئيسية</h3>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-8">
-        <a href="men.html" class="bg-white p-8 rounded-xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-blue-300 w-full">
+        <a href="men.html" class="bg-white p-8 rounded-2xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-blue-300 w-full">
           <i class="fas fa-mars text-5xl text-blue-500 mb-4"></i>
           <span class="text-xl font-bold">عطور رجالية</span>
         </a>
-        <a href="women.html" class="bg-white p-8 rounded-xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-pink-300 w-full">
+        <a href="women.html" class="bg-white p-8 rounded-2xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-pink-300 w-full">
           <i class="fas fa-venus text-5xl text-pink-500 mb-4"></i>
           <span class="text-xl font-bold">عطور نسائية</span>
         </a>
-        <a href="unisex.html" class="bg-white p-8 rounded-xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-purple-300 w-full">
+        <a href="unisex.html" class="bg-white p-8 rounded-2xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-purple-300 w-full">
           <i class="fas fa-venus-mars text-5xl text-purple-500 mb-4"></i>
           <span class="text-xl font-bold">عطور مختلطة</span>
         </a>
-        <a href="all.html" class="bg-white p-8 rounded-xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-yellow-300 w-full">
+        <a href="all.html" class="bg-white p-8 rounded-2xl shadow hover:shadow-lg transition flex flex-col items-center border-4 border-yellow-300 w-full">
           <i class="fas fa-th-large text-5xl text-yellow-500 mb-4"></i>
           <span class="text-xl font-bold">جميع العطور</span>
         </a>

--- a/men.html
+++ b/men.html
@@ -2,20 +2,12 @@
 <head>
   <meta charset="UTF-8">
   <title>مملكة العطور - الواجهة الجديدة</title>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-N8G1EZJT5B');
-</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
     body {
-      font-family: 'Cairo', sans-serif;
+      font-family: sans-serif;
       background-color: #f8fafc;
       overflow-x: hidden;
     }
@@ -23,7 +15,7 @@
     .product {
       background: white;
       padding: 1rem;
-      border-radius: 12px;
+      border-radius: 20px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       text-align: center;
       display: flex;
@@ -36,7 +28,7 @@
       max-width: 100%;
       height: 250px;
       object-fit: contain;
-      border-radius: 8px;
+      border-radius: 12px;
       margin-bottom: 1rem;
     }
     .product h3 {
@@ -69,7 +61,7 @@
       color: #1f2937;
       border: none;
       padding: 0.6rem 1rem;
-      border-radius: 6px;
+      border-radius: 12px;
       cursor: pointer;
       font-size: 0.95rem;
       transition: 0.3s;
@@ -100,11 +92,11 @@
     <div class="container mx-auto px-4">
       <h2 id="category-heading" class="text-2xl font-bold mb-6 text-center"></h2>
       <div class="flex flex-col md:flex-row gap-4 justify-between mb-6">
-        <form id="searchForm" class="flex bg-white rounded-lg overflow-hidden flex-1">
+        <form id="searchForm" class="flex bg-white rounded-full overflow-hidden flex-1">
           <input type="text" id="searchInput" placeholder="ابحث عن عطر..." class="px-4 py-2 flex-1 outline-none">
           <button type="submit" class="px-4 py-2 text-white"> <i class="fas fa-search"></i> </button>
         </form>
-        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded border border-gray-300">
+        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded-full border border-gray-300">
           <option value="all">جميع الأسعار</option>
           <option value="0-20000">أقل من 20000</option>
           <option value="20000-50000">20000 - 50000</option>

--- a/unisex.html
+++ b/unisex.html
@@ -2,27 +2,19 @@
 <head>
   <meta charset="UTF-8">
   <title>مملكة العطور - الواجهة الجديدة</title>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-N8G1EZJT5B');
-</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
     body {
-      font-family: 'Cairo', sans-serif;
+      font-family: sans-serif;
       background-color: #f8fafc;
     }
     .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;
-      border-radius: 12px;
+      border-radius: 20px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       text-align: center;
       display: flex;
@@ -35,7 +27,7 @@
       max-width: 100%;
       height: 250px;
       object-fit: contain;
-      border-radius: 8px;
+      border-radius: 12px;
       margin-bottom: 1rem;
     }
     .product h3 {
@@ -64,7 +56,7 @@
       color: #1f2937;
       border: none;
       padding: 0.6rem 1rem;
-      border-radius: 6px;
+      border-radius: 12px;
       cursor: pointer;
       font-size: 0.95rem;
       transition: 0.3s;
@@ -95,11 +87,11 @@
     <div class="container mx-auto px-4">
       <h2 id="category-heading" class="text-2xl font-bold mb-6 text-center"></h2>
       <div class="flex flex-col md:flex-row gap-4 justify-between mb-6">
-        <form id="searchForm" class="flex bg-white rounded-lg overflow-hidden flex-1">
+        <form id="searchForm" class="flex bg-white rounded-full overflow-hidden flex-1">
           <input type="text" id="searchInput" placeholder="ابحث عن عطر..." class="px-4 py-2 flex-1 outline-none">
           <button type="submit" class="px-4 py-2 text-white"> <i class="fas fa-search"></i> </button>
         </form>
-        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded border border-gray-300">
+        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded-full border border-gray-300">
           <option value="all">جميع الأسعار</option>
           <option value="0-20000">أقل من 20000</option>
           <option value="20000-50000">20000 - 50000</option>

--- a/women.html
+++ b/women.html
@@ -2,27 +2,19 @@
 <head>
   <meta charset="UTF-8">
   <title>مملكة العطور - الواجهة الجديدة</title>
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-N8G1EZJT5B"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-N8G1EZJT5B');
-</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap');
     body {
-      font-family: 'Cairo', sans-serif;
+      font-family: sans-serif;
       background-color: #f8fafc;
     }
     .container { max-width: 100%; }
     .product {
       background: white;
       padding: 1rem;
-      border-radius: 12px;
+      border-radius: 20px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       text-align: center;
       display: flex;
@@ -35,7 +27,7 @@
       max-width: 100%;
       height: 250px;
       object-fit: contain;
-      border-radius: 8px;
+      border-radius: 12px;
       margin-bottom: 1rem;
     }
     .product h3 {
@@ -64,7 +56,7 @@
       color: #1f2937;
       border: none;
       padding: 0.6rem 1rem;
-      border-radius: 6px;
+      border-radius: 12px;
       cursor: pointer;
       font-size: 0.95rem;
       transition: 0.3s;
@@ -95,11 +87,11 @@
     <div class="container mx-auto px-4">
       <h2 id="category-heading" class="text-2xl font-bold mb-6 text-center"></h2>
       <div class="flex flex-col md:flex-row gap-4 justify-between mb-6">
-        <form id="searchForm" class="flex bg-white rounded-lg overflow-hidden flex-1">
+        <form id="searchForm" class="flex bg-white rounded-full overflow-hidden flex-1">
           <input type="text" id="searchInput" placeholder="ابحث عن عطر..." class="px-4 py-2 flex-1 outline-none">
           <button type="submit" class="px-4 py-2 text-white"> <i class="fas fa-search"></i> </button>
         </form>
-        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded border border-gray-300">
+        <select id="priceFilter" class="w-full md:w-1/3 px-4 py-2 rounded-full border border-gray-300">
           <option value="all">جميع الأسعار</option>
           <option value="0-20000">أقل من 20000</option>
           <option value="20000-50000">20000 - 50000</option>


### PR DESCRIPTION
## Summary
- drop Google Tag Manager scripts and Google Fonts from all pages to avoid tracking
- apply fuller border radii to product cards, images and search UI

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a2b4a38832a82ee467c249d13ca