### PR TITLE
feat: add cart drawer and badge to product cards

### DIFF
--- a/all.html
+++ b/all.html
@@ -68,6 +68,7 @@
     }
     .symbol {
       font-size: 1.4rem;
+      margin-top: 1rem;
       margin-bottom: 0.4rem;
     }
     .product p {
@@ -76,6 +77,8 @@
     #scrollToTop {
       display: none;
     }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 20rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-gray-800">  <header class="text-white shadow-lg sticky top-0 z-50">
@@ -113,7 +116,16 @@
   </footer>  <a href="#" id="scrollToTop" class="fixed bottom-5 left-5 bg-yellow-400 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-yellow-500 transition z-50">
     <i class="fas fa-arrow-up"></i>
   </a>  
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     const productGrid = document.getElementById("product-grid");
     const searchInput = document.getElementById("searchInput");
@@ -173,11 +185,12 @@
           : product.desc.split(" - ")[1] || product.price + " أوقية";
         const descText = product.desc.split(" - ")[0];
         const symbols = productsData.symbols[product.name] || "";
-        const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
 
         productDiv.className = "product";
         productDiv.innerHTML = `
-          ${badgeHTML}
+          ${badgeHTML}${cartHTML}
           <div class="symbol">${symbols}</div>
           <img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/250?text=عطر'">
           <h3>${product.name}</h3>
@@ -192,8 +205,9 @@
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
 
     document.getElementById("year").textContent = new Date().getFullYear();

--- a/best.html
+++ b/best.html
@@ -46,8 +46,10 @@
       transition: 0.3s;
     }
     .product button.order-btn:hover { background-color: #eab308; }
-    .symbol { font-size: 1.2rem; margin-bottom: 0.25rem; }
+    .symbol { font-size: 1.2rem; margin-top: 1rem; margin-bottom: 0.25rem; }
     .product p { overflow-wrap: anywhere; }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 16rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-gray-800">
@@ -71,7 +73,16 @@
     <p>&copy; <span id="year"></span> مملكة العطور - جميع الحقوق محفوظة</p>
   </footer>
 
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
     const bestGrid = document.getElementById('bestGrid');
@@ -86,16 +97,18 @@
         : (product.desc.split(' - ')[1] || product.price + ' أوقية');
       const descText = product.desc.split(' - ')[0];
       const symbols = productsData.symbols[product.name] || '';
-      const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : '';
+      const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : '';
+      const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
       div.className = 'product';
-      div.innerHTML = `${badgeHTML}<div class="symbol">${symbols}</div><img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/150?text=عطر'"><h3>${product.name}</h3><div class="availability ${availabilityClass}">${availabilityText}</div><p>${descText}</p><p class="price">${priceText}</p><button class="order-btn" onclick="orderProduct('${product.name}')">اطلب الآن</button>`;
+      div.innerHTML = `${badgeHTML}${cartHTML}<div class="symbol">${symbols}</div><img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/150?text=عطر'"><h3>${product.name}</h3><div class="availability ${availabilityClass}">${availabilityText}</div><p>${descText}</p><p class="price">${priceText}</p><button class="order-btn" onclick="orderProduct('${product.name}')">اطلب الآن</button>`;
       bestGrid.appendChild(div);
     });
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
   </script>
 </body>

--- a/cart.js
+++ b/cart.js
@@ -1,0 +1,37 @@
+// Simple cart management
+const cartItems = [];
+
+function addToCart(product) {
+  cartItems.push(product);
+  updateCartCount();
+  renderCart();
+}
+
+function updateCartCount() {
+  document.querySelectorAll('.cart-count').forEach(el => {
+    el.textContent = cartItems.length;
+  });
+}
+
+function openCart() {
+  renderCart();
+  const drawer = document.getElementById('cartDrawer');
+  if (drawer) drawer.classList.add('open');
+}
+
+function closeCart() {
+  const drawer = document.getElementById('cartDrawer');
+  if (drawer) drawer.classList.remove('open');
+}
+
+function renderCart() {
+  const container = document.getElementById('cartItems');
+  if (!container) return;
+  if (cartItems.length === 0) {
+    container.innerHTML = '<p class="text-center text-gray-500 mt-4">عربة التسوق فارغة</p>';
+    return;
+  }
+  container.innerHTML = cartItems.map(item =>
+    `<div class="flex justify-between border-b py-2"><span>${item.name}</span><span class="text-yellow-500 font-bold">${item.price} أوقية</span></div>`
+  ).join('');
+}

--- a/discounts.html
+++ b/discounts.html
@@ -45,8 +45,10 @@
       transition: 0.3s;
     }
     .product button.order-btn:hover { background-color: #eab308; }
-    .symbol { font-size: 1.2rem; margin-bottom: 0.25rem; }
+    .symbol { font-size: 1.2rem; margin-top: 1rem; margin-bottom: 0.25rem; }
     .product p { overflow-wrap: anywhere; }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 16rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-gray-800">
@@ -71,7 +73,16 @@
     <p>&copy; <span id="year"></span> مملكة العطور - جميع الحقوق محفوظة</p>
   </footer>
 
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
     const discountGrid = document.getElementById('discountGrid');
@@ -88,17 +99,19 @@
         const priceText = `<span class="line-through text-red-500">${product.originalPrice} أوقية</span> <span class="text-yellow-500">${product.price} أوقية</span> (${Math.round((1 - product.price / product.originalPrice) * 100)}% خصم)`;
         const descText = product.desc.split(' - ')[0];
         const symbols = productsData.symbols[product.name] || '';
-        const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : '';
+        const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : '';
+        const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
         div.className = 'product';
-        div.innerHTML = `${badgeHTML}<div class="symbol">${symbols}</div><img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/150?text=عطر'"><h3>${product.name}</h3><div class="availability ${availabilityClass}">${availabilityText}</div><p>${descText}</p><p class="price">${priceText}</p><button class="order-btn" onclick="orderProduct('${product.name}')">اطلب الآن</button>`;
+        div.innerHTML = `${badgeHTML}${cartHTML}<div class="symbol">${symbols}</div><img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/150?text=عطر'"><h3>${product.name}</h3><div class="availability ${availabilityClass}">${availabilityText}</div><p>${descText}</p><p class="price">${priceText}</p><button class="order-btn" onclick="orderProduct('${product.name}')">اطلب الآن</button>`;
         discountGrid.appendChild(div);
       });
     }
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -43,8 +43,10 @@
       transition: 0.3s;
     }
     .product button.order-btn:hover { background-color: #eab308; }
-    .symbol { font-size: 1.2rem; margin-bottom: 0.25rem; }
+    .symbol { font-size: 1.2rem; margin-top: 1rem; margin-bottom: 0.25rem; }
     .product p { overflow-wrap: anywhere; }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 16rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-gray-800">
@@ -121,7 +123,16 @@
     <p>&copy; <span id="year"></span> مملكة العطور - جميع الحقوق محفوظة</p>
   </footer>
 
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
 
@@ -157,9 +168,10 @@
           ? `<span class="line-through text-red-500">${product.originalPrice} أوقية</span> <span class="text-yellow-500">${product.price} أوقية</span> (${Math.round((1 - product.price / product.originalPrice) * 100)}% خصم)`
           : (product.desc.split(' - ')[1] || product.price + ' أوقية');
         const symbols = productsData.symbols[product.name] || '';
-        const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : '';
+        const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : '';
+        const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
         div.className = 'product';
-        div.innerHTML = `${badgeHTML}<div class="symbol">${symbols}</div><img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/150?text=عطر'"><h3>${product.name}</h3><div class="availability ${availabilityClass}">${availabilityText}</div><p class="price">${priceText}</p><button class="order-btn" onclick="orderProduct('${product.name}')">اطلب الآن</button>`;
+        div.innerHTML = `${badgeHTML}${cartHTML}<div class="symbol">${symbols}</div><img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/150?text=عطر'"><h3>${product.name}</h3><div class="availability ${availabilityClass}">${availabilityText}</div><p class="price">${priceText}</p><button class="order-btn" onclick="orderProduct('${product.name}')">اطلب الآن</button>`;
         searchResults.appendChild(div);
       });
 
@@ -187,8 +199,9 @@
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
   </script>
 </body>

--- a/men.html
+++ b/men.html
@@ -71,11 +71,14 @@
     }
     .symbol {
       font-size: 1.4rem;
+      margin-top: 1rem;
       margin-bottom: 0.4rem;
     }
     #scrollToTop {
       display: none;
     }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 20rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-white">  <header class="text-white shadow-lg sticky top-0 z-50">
@@ -113,7 +116,16 @@
   </footer>  <a href="#" id="scrollToTop" class="fixed bottom-5 left-5 bg-yellow-400 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-yellow-500 transition z-50">
     <i class="fas fa-arrow-up"></i>
   </a>  
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     const productGrid = document.getElementById("product-grid");
     const searchInput = document.getElementById("searchInput");
@@ -174,11 +186,12 @@
           : product.desc.split(" - ")[1] || product.price + " أوقية";
         const descText = product.desc.split(" - ")[0];
         const symbols = productsData.symbols[product.name] || "";
-        const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
 
         productDiv.className = "product";
         productDiv.innerHTML = `
-          ${badgeHTML}
+          ${badgeHTML}${cartHTML}
           <div class="symbol">${symbols}</div>
           <img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/250?text=عطر'">
           <h3>${product.name}</h3>
@@ -193,8 +206,9 @@
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
 
     document.getElementById("year").textContent = new Date().getFullYear();

--- a/unisex.html
+++ b/unisex.html
@@ -66,11 +66,14 @@
     }
     .symbol {
       font-size: 1.4rem;
+      margin-top: 1rem;
       margin-bottom: 0.4rem;
     }
     #scrollToTop {
       display: none;
     }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 20rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-gray-800">  <header class="text-white shadow-lg sticky top-0 z-50">
@@ -108,7 +111,16 @@
   </footer>  <a href="#" id="scrollToTop" class="fixed bottom-5 left-5 bg-yellow-400 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-yellow-500 transition z-50">
     <i class="fas fa-arrow-up"></i>
   </a>  
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     const productGrid = document.getElementById("product-grid");
     const searchInput = document.getElementById("searchInput");
@@ -168,11 +180,12 @@
           : product.desc.split(" - ")[1] || product.price + " أوقية";
         const descText = product.desc.split(" - ")[0];
         const symbols = productsData.symbols[product.name] || "";
-        const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
 
         productDiv.className = "product";
         productDiv.innerHTML = `
-          ${badgeHTML}
+          ${badgeHTML}${cartHTML}
           <div class="symbol">${symbols}</div>
           <img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/250?text=عطر'">
           <h3>${product.name}</h3>
@@ -187,8 +200,9 @@
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
 
     document.getElementById("year").textContent = new Date().getFullYear();

--- a/women.html
+++ b/women.html
@@ -66,11 +66,14 @@
     }
     .symbol {
       font-size: 1.4rem;
+      margin-top: 1rem;
       margin-bottom: 0.4rem;
     }
     #scrollToTop {
       display: none;
     }
+    #cartDrawer { position: fixed; top: 0; right: 0; width: 20rem; max-width: 80%; height: 100%; background: white; box-shadow: -2px 0 10px rgba(0,0,0,0.2); transform: translateX(100%); transition: transform 0.3s ease; z-index: 1000; }
+    #cartDrawer.open { transform: translateX(0); }
   </style>
 </head>
 <body class="text-gray-800">  <header class="text-white shadow-lg sticky top-0 z-50">
@@ -108,7 +111,16 @@
   </footer>  <a href="#" id="scrollToTop" class="fixed bottom-5 left-5 bg-yellow-400 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-yellow-500 transition z-50">
     <i class="fas fa-arrow-up"></i>
   </a>  
+  <div id="cartDrawer">
+    <div class="p-4 border-b flex justify-between items-center">
+      <h2 class="text-lg font-bold">السلة</h2>
+      <button onclick="closeCart()" class="text-gray-600">&times;</button>
+    </div>
+    <div id="cartItems" class="p-4 space-y-2 overflow-y-auto"></div>
+  </div>
+
   <script src="products-data.js"></script>
+  <script src="cart.js"></script>
   <script>
     const productGrid = document.getElementById("product-grid");
     const searchInput = document.getElementById("searchInput");
@@ -169,11 +181,12 @@
           : product.desc.split(" - ")[1] || product.price + " أوقية";
         const descText = product.desc.split(" - ")[0];
         const symbols = productsData.symbols[product.name] || "";
-        const badgeHTML = product.badge ? `<span class="absolute top-2 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const badgeHTML = product.badge ? `<span class="absolute top-1 right-2 ${product.badge === 'الأكثر مبيعاً' ? 'bg-yellow-500' : 'bg-red-500'} text-white text-xs px-2 py-1 rounded">${product.badge}</span>` : "";
+        const cartHTML = `<button class="absolute top-1 left-2 bg-yellow-500 text-white rounded-full w-8 h-8 flex items-center justify-center" onclick="openCart()"><i class="fas fa-shopping-cart"></i><span class="cart-count absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-4 h-4 flex items-center justify-center">0</span></button>`;
 
         productDiv.className = "product";
         productDiv.innerHTML = `
-          ${badgeHTML}
+          ${badgeHTML}${cartHTML}
           <div class="symbol">${symbols}</div>
           <img src="${product.img}" alt="${product.name}" loading="lazy" onerror="this.src='https://via.placeholder.com/250?text=عطر'">
           <h3>${product.name}</h3>
@@ -188,8 +201,9 @@
 
     function orderProduct(name) {
       const product = productsData.products.find(p => p.name === name);
+      addToCart(product);
       const message = `مرحبًا، أرغب بطلب عطر ${name} بسعر ${product.price} أوقية`;
-      window.location.href = `https://wa.me/22246099296?text=${encodeURIComponent(message)}`;
+      window.open(`https://wa.me/22246099296?text=${encodeURIComponent(message)}`, '_blank');
     }
 
     document.getElementById("year").textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- add reusable cart script for badge counts and drawer
- position cart icon opposite badges and adjust symbol spacing across product cards
- update order buttons to populate cart and open WhatsApp in new tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cea46d44832c9a83cedfd10f233b