### PR TITLE
Fix cart toast link path and restore Dior Sauvage imagery

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -119,12 +119,25 @@ function updateCartCount(){
   if(count>0){ countEl.classList.remove('hidden'); } else { countEl.classList.add('hidden'); }
 }
 
+function getCartLink(){
+  const path = window.location.pathname;
+  const segments = path.split('/').filter(Boolean);
+  let depth = segments.length;
+  if (!path.endsWith('/') && segments.length && segments[segments.length - 1].includes('.')) {
+    depth -= 1;
+  }
+  return `${'../'.repeat(depth)}cart.html`;
+}
+
 function showToast(message, withCart){
   const existing = document.getElementById('cartToast');
   if(existing) existing.remove();
   const msg = document.createElement('div');
   msg.id = 'cartToast';
-  msg.innerHTML = withCart ? `<span>${message}</span><a href="cart.html" class="underline">${t('titles.cart')}</a>` : `<span>${message}</span>`;
+  const cartLink = getCartLink();
+  msg.innerHTML = withCart
+    ? `<span>${message}</span><a href="${cartLink}" class="underline">${t('titles.cart')}</a>`
+    : `<span>${message}</span>`;
   document.body.appendChild(msg);
   setTimeout(()=>{ msg.classList.add('fade-out'); setTimeout(()=>msg.remove(),300); },2500);
 }

--- a/product/dior-sauvage.html
+++ b/product/dior-sauvage.html
@@ -6,7 +6,7 @@
   <meta name="description" content="اكتشف قوة وانتعاش عطر Dior Sauvage الرجالي بنفحاته البرية المنعشة وثباته العالي."/>
   <meta property="og:title" content="Dior Sauvage"/>
   <meta property="og:description" content="جاذبية عصرية تجمع بين الفلفل الحار والحمضيات مع عطر Dior Sauvage."/>
-  <meta property="og:image" content="../image/dior1.png"/>
+  <meta property="og:image" content="../image/Dior_sauvage_200ml.png"/>
   <meta property="og:type" content="product"/>
   <link rel="icon" type="image/svg+xml" href="../image/favicon.svg">
   <link rel="apple-touch-icon" sizes="180x180" href="../image/apple-touch-icon.png">
@@ -71,7 +71,7 @@
           </div>
         </div>
         <div class="gallery">
-          <img src="../image/dior1.png" alt="Dior Sauvage زجاجة العطر" loading="lazy">
+          <img src="../image/Dior_sauvage_200ml.png" alt="Dior Sauvage زجاجة العطر" loading="lazy">
           <img src="../image/dior2.png" alt="Dior Sauvage تصميم العبوة" loading="lazy">
           <img src="../image/dior3.png" alt="Dior Sauvage تفاصيل فنية" loading="lazy">
           <img src="../image/dior4.png" alt="Dior Sauvage مشهد ملهم" loading="lazy">

--- a/products-data.js
+++ b/products-data.js
@@ -1,7 +1,7 @@
     const localProductsData = {
       products: [
            { name: 'jean paul gaultier le male elixir', desc: 'عطر شبابي عصري بنفحات حارة - 0000 MRU', img: 'image/jean_paul_gaultier_le_male_elixir.png', category: 'men', price: '0000', available: true, detailPage: 'product/jean-paul-gaultier-le-male-elixir.html' },
-        { name: 'Dior sauvage', desc: 'أحد أشهر العطور الرجالية حول العالم - 0000 MRU', img: 'image/dior1.svg', category: 'men', price: '0000', available: true, badge: 'الأكثر مبيعاً', detailPage: 'product/dior-sauvage.html' },
+        { name: 'Dior sauvage', desc: 'أحد أشهر العطور الرجالية حول العالم - 0000 MRU', img: 'image/Dior_sauvage_200ml.png', category: 'men', price: '0000', available: true, badge: 'الأكثر مبيعاً', detailPage: 'product/dior-sauvage.html' },
         { name: 'officer', desc: 'عطر رسمي أنيق يلائم جميع المناسبات - 0000 MRU', img: 'image/officer.png', category: 'men', price: '0000', available: true, badge: 'الأكثر مبيعاً' },
         { name: 'jean_paul_gaultier_paradise', desc: 'عطر شبابي فاخر بنفحات برية منعشة - 0000 MRU', img: 'image/jean_paul_gaultier_paradise.png', category: 'men', price: '0000', available: true, badge: 'جديد' },
         { name: 'tom_ford_noir', desc: 'عطر رجالي غامض بنفحات خشبية دافئة - 0000 MRU', img: 'image/tom_ford_noir.png', category: 'men', price: '0000', available: false, badge: 'الأكثر مبيعاً' },


### PR DESCRIPTION
## Summary
- ensure the add-to-cart toast links to the correct cart page regardless of directory depth
- restore the Dior Sauvage product image and detail preview to the original Dior_sauvage_200ml.png asset
- update Dior Sauvage metadata to use the restored artwork

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ac233820832c869bf7816fbea852